### PR TITLE
Depcheck-es6 is merged back to depcheck now!

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "clarinet": "^0.11.0",
     "commander": "^2.9.0",
     "deepmerge": "^0.2.10",
-    "depcheck-es6": "0.5.5",
+    "depcheck": "^0.5.9",
     "file-seeker": "^0.1.0",
     "inquirer": "^0.10.1",
     "is-my-json-valid": "^2.12.2",


### PR DESCRIPTION
Hi, @mathieudutour.

@rumpl and I decided to merge depcheck-es6 back to [depcheck](https://github.com/depcheck/depcheck) and move the repo under an organization. I will continue to develop and maintain the project, all new releases will go back to [depcheck package](https://www.npmjs.com/package/depcheck) now.

A new version, 0.5.9, is released on depcheck. Its function is same as depcheck-es6 0.5.8. As said before, the 0.5.x versions will be fully backward compatible with the older versions. No code changes on your side.

The depcheck-es6 package will be deprecated after all dependents migrate to depcheck.

Thanks for understanding!

-Junle
